### PR TITLE
[AE-575]: Add tests for all the models

### DIFF
--- a/flux-dev/tests/README.md
+++ b/flux-dev/tests/README.md
@@ -1,0 +1,23 @@
+# Tests for FLUX DEV
+
+This directory contains tests for the FLUX DEV endpoint.
+
+## Running Tests
+
+To run the tests, ensure the following environment variables are set:
+
+- `RUNPOD_API_KEY`
+- `ENDPOINT_ID`
+
+
+Ensure all dependencies are installed before running the tests:
+
+```bash
+pip install pytest pytest-asyncio aiohttp pillow
+```
+
+You can then execute the tests using the following command:
+
+```bash
+pytest test_txt2img.py -v
+```

--- a/flux-dev/tests/test_txt2img.py
+++ b/flux-dev/tests/test_txt2img.py
@@ -1,0 +1,82 @@
+import pytest
+import aiohttp
+import asyncio
+import json
+import base64
+import os
+from PIL import Image
+import io
+import time
+from utils import make_api_request, is_valid_image
+
+# Test 1: Basic functionality - verify the API can generate an image with default settings
+@pytest.mark.asyncio
+async def test_basic_functionality():
+    print("\n--- Running Basic Functionality Test ---")
+    
+    # Standard payload with minimal requirements
+    payload = {
+        "input": {
+            "prompt": "a photograph of a dog in a park",
+        }
+    }
+    
+    #
+    result = await make_api_request(payload)
+    
+    # Test that the response is successful
+    assert result["status_code"] == 200, f"API returned status code {result['status_code']}"
+    
+    # Test the response format
+    data = result["json_data"]
+    assert data["status"] == "success", f"API returned status: {data.get('status')}"
+    assert "image" in data, "Response missing 'image' field"
+    assert "data_url" in data, "Response missing 'data_url' field"
+    
+    # Test that the response contains a valid image
+    image_data = base64.b64decode(data["image"])
+    assert is_valid_image(image_data), "Generated image is not valid"
+    
+    print("--- Basic Functionality Test PASSED ---")
+
+# Test 2: Parameter functionality - verify the API correctly handles custom parameters
+@pytest.mark.asyncio
+async def test_parameter_functionality():
+    print("\n--- Running Parameter Functionality Test ---")
+    
+    # Payload with custom parameters
+    payload = {
+        "input": {
+            "prompt": "a photo of a cat",
+            "negative_prompt": "blurry, low quality",
+            "height": 512,
+            "width": 512,
+            "num_inference_steps": 30,
+            "guidance": 7.5
+        }
+    }
+    
+    # Make the API request
+    result = await make_api_request(payload)
+    
+    # Test that the response is successful
+    assert result["status_code"] == 200, f"API returned status code {result['status_code']}"
+    
+    # Test the response format
+    data = result["json_data"]
+    assert data["status"] == "success", f"API returned status: {data.get('status')}"
+    assert "image" in data, "Response missing 'image' field"
+    
+    # Test that the response contains a valid image
+    image_data = base64.b64decode(data["image"])
+    assert is_valid_image(image_data), "Generated image is not valid"
+    
+    # Optionally check image dimensions if your API respects them exactly
+    try:
+        img = Image.open(io.BytesIO(image_data))
+        print(f"Generated image dimensions: {img.width}x{img.height}")
+        # assert img.width == 512, f"Image width is {img.width}, expected 512"
+        # assert img.height == 512, f"Image height is {img.height}, expected 512"
+    except Exception as e:
+        print(f"Could not verify image dimensions: {e}")
+    

--- a/flux-dev/tests/utils.py
+++ b/flux-dev/tests/utils.py
@@ -1,0 +1,106 @@
+
+import aiohttp
+import asyncio
+import os
+from PIL import Image
+import io
+import time
+
+
+
+API_URL = f"https://api.runpod.ai/v2/{os.getenv('ENDPOINT_ID')}/run"
+API_KEY = os.getenv("RUNPOD_API_KEY")  # Store API key in environment variable
+
+
+# Helper function to validate image data
+def is_valid_image(image_data):
+    try:
+        Image.open(io.BytesIO(image_data))
+        return True
+    except Exception as e:
+        print(f"Image validation error: {e}")
+        return False
+
+
+async def make_api_request(payload):
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {API_KEY}"
+    }
+    
+    start_time = time.time()
+    print(f"Sending request to {API_URL}...")
+    
+    async with aiohttp.ClientSession() as session:
+        # Initial request to start the job
+        async with session.post(API_URL, json=payload, headers=headers, timeout=120) as response:
+            initial_response = await response.json()
+            
+            # Check for immediate errors
+            if response.status != 200:
+                elapsed_time = time.time() - start_time
+                print(f"Request failed with status {response.status} in {elapsed_time:.2f} seconds")
+                return {
+                    "status_code": response.status,
+                    "elapsed_time": elapsed_time,
+                    "json_data": initial_response,
+                    "state": "FAILED"
+                }
+            
+            # Get the request_id (job ID) from the response
+            request_id = initial_response.get("id")
+            if not request_id:
+                elapsed_time = time.time() - start_time
+                print(f"Request failed in {elapsed_time:.2f} seconds - no job id received")
+                return {
+                    "status_code": response.status,
+                    "elapsed_time": elapsed_time,
+                    "json_data": initial_response,
+                    "state": "FAILED"
+                }
+            
+            print(f"Job submitted with ID: {request_id}")
+        
+        # Poll until COMPLETED or FAILED
+        status_url = f"{API_URL.replace('/run', '')}/status/{request_id}"
+        
+        while True:
+            async with session.get(status_url, headers=headers, timeout=30) as status_response:
+                status_data = await status_response.json()
+                current_state = status_data.get("status", "UNKNOWN")
+                
+                elapsed_time = time.time() - start_time
+                print(f"Current state: {current_state}, elapsed time: {elapsed_time:.2f} seconds")
+                
+                # Return on terminal states
+                if current_state in ["COMPLETED", "FAILED", "CANCELLED"]:
+                    # If completed, format the response to match what the tests expect
+                    if current_state == "COMPLETED":
+                        # Extract the output data from the nested structure RunPod uses
+                        output = status_data.get("output", {})
+                        
+                        # Format to match what the tests expect
+                        formatted_data = {
+                            "status": "success",
+                            "image": output.get("image", ""),
+                            "data_url": output.get("data_url", "")
+                        }
+                        
+                        return {
+                            "status_code": status_response.status,
+                            "elapsed_time": elapsed_time,
+                            "json_data": formatted_data,
+                            "state": current_state
+                        }
+                    else:
+                        # For failed or cancelled states
+                        return {
+                            "status_code": status_response.status,
+                            "elapsed_time": elapsed_time,
+                            "json_data": {"status": "error", "message": status_data.get("error", "Unknown error")},
+                            "state": current_state
+                        }
+                
+                # Wait before polling again - exponential backoff might be better
+                # for production but keeping simple for tests
+                await asyncio.sleep(2)

--- a/flux-schnell/tests/README.md
+++ b/flux-schnell/tests/README.md
@@ -1,0 +1,23 @@
+# Tests for FLUX SCHNELL
+
+This directory contains tests for the FLUX SCHNELL endpoint.
+
+## Running Tests
+
+To run the tests, ensure the following environment variables are set:
+
+- `RUNPOD_API_KEY`
+- `ENDPOINT_ID`
+
+
+Ensure all dependencies are installed before running the tests:
+
+```bash
+pip install pytest pytest-asyncio aiohttp pillow
+```
+
+You can then execute the tests using the following command:
+
+```bash
+pytest test_txt2img.py -v
+```

--- a/flux-schnell/tests/test_txt2img.py
+++ b/flux-schnell/tests/test_txt2img.py
@@ -1,0 +1,82 @@
+import pytest
+import aiohttp
+import asyncio
+import json
+import base64
+import os
+from PIL import Image
+import io
+import time
+from utils import make_api_request, is_valid_image
+
+# Test 1: Basic functionality - verify the API can generate an image with default settings
+@pytest.mark.asyncio
+async def test_basic_functionality():
+    print("\n--- Running Basic Functionality Test ---")
+    
+    # Standard payload with minimal requirements
+    payload = {
+        "input": {
+            "prompt": "a photograph of a dog in a park",
+        }
+    }
+    
+    #
+    result = await make_api_request(payload)
+    
+    # Test that the response is successful
+    assert result["status_code"] == 200, f"API returned status code {result['status_code']}"
+    
+    # Test the response format
+    data = result["json_data"]
+    assert data["status"] == "success", f"API returned status: {data.get('status')}"
+    assert "image" in data, "Response missing 'image' field"
+    assert "data_url" in data, "Response missing 'data_url' field"
+    
+    # Test that the response contains a valid image
+    image_data = base64.b64decode(data["image"])
+    assert is_valid_image(image_data), "Generated image is not valid"
+    
+    print("--- Basic Functionality Test PASSED ---")
+
+# Test 2: Parameter functionality - verify the API correctly handles custom parameters
+@pytest.mark.asyncio
+async def test_parameter_functionality():
+    print("\n--- Running Parameter Functionality Test ---")
+    
+    # Payload with custom parameters
+    payload = {
+        "input": {
+            "prompt": "a photo of a cat",
+            "negative_prompt": "blurry, low quality",
+            "height": 512,
+            "width": 512,
+            "num_inference_steps": 30,
+            "guidance": 7.5
+        }
+    }
+    
+    # Make the API request
+    result = await make_api_request(payload)
+    
+    # Test that the response is successful
+    assert result["status_code"] == 200, f"API returned status code {result['status_code']}"
+    
+    # Test the response format
+    data = result["json_data"]
+    assert data["status"] == "success", f"API returned status: {data.get('status')}"
+    assert "image" in data, "Response missing 'image' field"
+    
+    # Test that the response contains a valid image
+    image_data = base64.b64decode(data["image"])
+    assert is_valid_image(image_data), "Generated image is not valid"
+    
+    # Optionally check image dimensions if your API respects them exactly
+    try:
+        img = Image.open(io.BytesIO(image_data))
+        print(f"Generated image dimensions: {img.width}x{img.height}")
+        # assert img.width == 512, f"Image width is {img.width}, expected 512"
+        # assert img.height == 512, f"Image height is {img.height}, expected 512"
+    except Exception as e:
+        print(f"Could not verify image dimensions: {e}")
+    

--- a/flux-schnell/tests/utils.py
+++ b/flux-schnell/tests/utils.py
@@ -1,0 +1,106 @@
+
+import aiohttp
+import asyncio
+import os
+from PIL import Image
+import io
+import time
+
+
+
+API_URL = f"https://api.runpod.ai/v2/{os.getenv('ENDPOINT_ID')}/run"
+API_KEY = os.getenv("RUNPOD_API_KEY")  # Store API key in environment variable
+
+
+# Helper function to validate image data
+def is_valid_image(image_data):
+    try:
+        Image.open(io.BytesIO(image_data))
+        return True
+    except Exception as e:
+        print(f"Image validation error: {e}")
+        return False
+
+
+async def make_api_request(payload):
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {API_KEY}"
+    }
+    
+    start_time = time.time()
+    print(f"Sending request to {API_URL}...")
+    
+    async with aiohttp.ClientSession() as session:
+        # Initial request to start the job
+        async with session.post(API_URL, json=payload, headers=headers, timeout=120) as response:
+            initial_response = await response.json()
+            
+            # Check for immediate errors
+            if response.status != 200:
+                elapsed_time = time.time() - start_time
+                print(f"Request failed with status {response.status} in {elapsed_time:.2f} seconds")
+                return {
+                    "status_code": response.status,
+                    "elapsed_time": elapsed_time,
+                    "json_data": initial_response,
+                    "state": "FAILED"
+                }
+            
+            # Get the request_id (job ID) from the response
+            request_id = initial_response.get("id")
+            if not request_id:
+                elapsed_time = time.time() - start_time
+                print(f"Request failed in {elapsed_time:.2f} seconds - no job id received")
+                return {
+                    "status_code": response.status,
+                    "elapsed_time": elapsed_time,
+                    "json_data": initial_response,
+                    "state": "FAILED"
+                }
+            
+            print(f"Job submitted with ID: {request_id}")
+        
+        # Poll until COMPLETED or FAILED
+        status_url = f"{API_URL.replace('/run', '')}/status/{request_id}"
+        
+        while True:
+            async with session.get(status_url, headers=headers, timeout=30) as status_response:
+                status_data = await status_response.json()
+                current_state = status_data.get("status", "UNKNOWN")
+                
+                elapsed_time = time.time() - start_time
+                print(f"Current state: {current_state}, elapsed time: {elapsed_time:.2f} seconds")
+                
+                # Return on terminal states
+                if current_state in ["COMPLETED", "FAILED", "CANCELLED"]:
+                    # If completed, format the response to match what the tests expect
+                    if current_state == "COMPLETED":
+                        # Extract the output data from the nested structure RunPod uses
+                        output = status_data.get("output", {})
+                        
+                        # Format to match what the tests expect
+                        formatted_data = {
+                            "status": "success",
+                            "image": output.get("image", ""),
+                            "data_url": output.get("data_url", "")
+                        }
+                        
+                        return {
+                            "status_code": status_response.status,
+                            "elapsed_time": elapsed_time,
+                            "json_data": formatted_data,
+                            "state": current_state
+                        }
+                    else:
+                        # For failed or cancelled states
+                        return {
+                            "status_code": status_response.status,
+                            "elapsed_time": elapsed_time,
+                            "json_data": {"status": "error", "message": status_data.get("error", "Unknown error")},
+                            "state": current_state
+                        }
+                
+                # Wait before polling again - exponential backoff might be better
+                # for production but keeping simple for tests
+                await asyncio.sleep(2)

--- a/sd3/tests/README.md
+++ b/sd3/tests/README.md
@@ -1,0 +1,23 @@
+# Tests for Stable Diffusion 3
+
+This directory contains tests for the Stable Diffusion 3 endpoint.
+
+## Running Tests
+
+To run the tests, ensure the following environment variables are set:
+
+- `RUNPOD_API_KEY`
+- `ENDPOINT_ID`
+
+
+Ensure all dependencies are installed before running the tests:
+
+```bash
+pip install pytest pytest-asyncio aiohttp pillow
+```
+
+You can then execute the tests using the following command:
+
+```bash
+pytest test_txt2img.py -v
+```

--- a/sd3/tests/test_txt2img.py
+++ b/sd3/tests/test_txt2img.py
@@ -1,0 +1,82 @@
+import pytest
+import aiohttp
+import asyncio
+import json
+import base64
+import os
+from PIL import Image
+import io
+import time
+from utils import make_api_request, is_valid_image
+
+# Test 1: Basic functionality - verify the API can generate an image with default settings
+@pytest.mark.asyncio
+async def test_basic_functionality():
+    print("\n--- Running Basic Functionality Test ---")
+    
+    # Standard payload with minimal requirements
+    payload = {
+        "input": {
+            "prompt": "a photograph of a dog in a park",
+        }
+    }
+    
+    #
+    result = await make_api_request(payload)
+    
+    # Test that the response is successful
+    assert result["status_code"] == 200, f"API returned status code {result['status_code']}"
+    
+    # Test the response format
+    data = result["json_data"]
+    assert data["status"] == "success", f"API returned status: {data.get('status')}"
+    assert "image" in data, "Response missing 'image' field"
+    assert "data_url" in data, "Response missing 'data_url' field"
+    
+    # Test that the response contains a valid image
+    image_data = base64.b64decode(data["image"])
+    assert is_valid_image(image_data), "Generated image is not valid"
+    
+    print("--- Basic Functionality Test PASSED ---")
+
+# Test 2: Parameter functionality - verify the API correctly handles custom parameters
+@pytest.mark.asyncio
+async def test_parameter_functionality():
+    print("\n--- Running Parameter Functionality Test ---")
+    
+    # Payload with custom parameters
+    payload = {
+        "input": {
+            "prompt": "a photo of a cat",
+            "negative_prompt": "blurry, low quality",
+            "height": 512,
+            "width": 512,
+            "num_inference_steps": 30,
+            "guidance": 7.5
+        }
+    }
+    
+    # Make the API request
+    result = await make_api_request(payload)
+    
+    # Test that the response is successful
+    assert result["status_code"] == 200, f"API returned status code {result['status_code']}"
+    
+    # Test the response format
+    data = result["json_data"]
+    assert data["status"] == "success", f"API returned status: {data.get('status')}"
+    assert "image" in data, "Response missing 'image' field"
+    
+    # Test that the response contains a valid image
+    image_data = base64.b64decode(data["image"])
+    assert is_valid_image(image_data), "Generated image is not valid"
+    
+    # Optionally check image dimensions if your API respects them exactly
+    try:
+        img = Image.open(io.BytesIO(image_data))
+        print(f"Generated image dimensions: {img.width}x{img.height}")
+        # assert img.width == 512, f"Image width is {img.width}, expected 512"
+        # assert img.height == 512, f"Image height is {img.height}, expected 512"
+    except Exception as e:
+        print(f"Could not verify image dimensions: {e}")
+    

--- a/sd3/tests/utils.py
+++ b/sd3/tests/utils.py
@@ -1,0 +1,106 @@
+
+import aiohttp
+import asyncio
+import os
+from PIL import Image
+import io
+import time
+
+
+
+API_URL = f"https://api.runpod.ai/v2/{os.getenv('ENDPOINT_ID')}/run"
+API_KEY = os.getenv("RUNPOD_API_KEY")  # Store API key in environment variable
+
+
+# Helper function to validate image data
+def is_valid_image(image_data):
+    try:
+        Image.open(io.BytesIO(image_data))
+        return True
+    except Exception as e:
+        print(f"Image validation error: {e}")
+        return False
+
+
+async def make_api_request(payload):
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {API_KEY}"
+    }
+    
+    start_time = time.time()
+    print(f"Sending request to {API_URL}...")
+    
+    async with aiohttp.ClientSession() as session:
+        # Initial request to start the job
+        async with session.post(API_URL, json=payload, headers=headers, timeout=120) as response:
+            initial_response = await response.json()
+            
+            # Check for immediate errors
+            if response.status != 200:
+                elapsed_time = time.time() - start_time
+                print(f"Request failed with status {response.status} in {elapsed_time:.2f} seconds")
+                return {
+                    "status_code": response.status,
+                    "elapsed_time": elapsed_time,
+                    "json_data": initial_response,
+                    "state": "FAILED"
+                }
+            
+            # Get the request_id (job ID) from the response
+            request_id = initial_response.get("id")
+            if not request_id:
+                elapsed_time = time.time() - start_time
+                print(f"Request failed in {elapsed_time:.2f} seconds - no job id received")
+                return {
+                    "status_code": response.status,
+                    "elapsed_time": elapsed_time,
+                    "json_data": initial_response,
+                    "state": "FAILED"
+                }
+            
+            print(f"Job submitted with ID: {request_id}")
+        
+        # Poll until COMPLETED or FAILED
+        status_url = f"{API_URL.replace('/run', '')}/status/{request_id}"
+        
+        while True:
+            async with session.get(status_url, headers=headers, timeout=30) as status_response:
+                status_data = await status_response.json()
+                current_state = status_data.get("status", "UNKNOWN")
+                
+                elapsed_time = time.time() - start_time
+                print(f"Current state: {current_state}, elapsed time: {elapsed_time:.2f} seconds")
+                
+                # Return on terminal states
+                if current_state in ["COMPLETED", "FAILED", "CANCELLED"]:
+                    # If completed, format the response to match what the tests expect
+                    if current_state == "COMPLETED":
+                        # Extract the output data from the nested structure RunPod uses
+                        output = status_data.get("output", {})
+                        
+                        # Format to match what the tests expect
+                        formatted_data = {
+                            "status": "success",
+                            "image": output.get("image", ""),
+                            "data_url": output.get("data_url", "")
+                        }
+                        
+                        return {
+                            "status_code": status_response.status,
+                            "elapsed_time": elapsed_time,
+                            "json_data": formatted_data,
+                            "state": current_state
+                        }
+                    else:
+                        # For failed or cancelled states
+                        return {
+                            "status_code": status_response.status,
+                            "elapsed_time": elapsed_time,
+                            "json_data": {"status": "error", "message": status_data.get("error", "Unknown error")},
+                            "state": current_state
+                        }
+                
+                # Wait before polling again - exponential backoff might be better
+                # for production but keeping simple for tests
+                await asyncio.sleep(2)


### PR DESCRIPTION
This PR contains two generic tests for validation of the i/o. 
[[AE-575]](https://linear.app/runpod/issue/AE-575/public-endpoints-add-tests-to-the-endpoints-created)